### PR TITLE
chore: #ENABLING-567 redirect old path before rendering

### DIFF
--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -3,6 +3,7 @@ import { RouteObject, createBrowserRouter } from 'react-router-dom';
 
 import { NotFound } from './errors/not-found';
 import { PageError } from './errors/page-error';
+import { manageRedirections } from './redirections';
 
 const routes = (queryClient: QueryClient): RouteObject[] => [
   /* Main route */
@@ -26,7 +27,15 @@ const routes = (queryClient: QueryClient): RouteObject[] => [
 
 export const basename = import.meta.env.PROD ? '/boilerplate' : '/';
 
-export const router = (queryClient: QueryClient) =>
-  createBrowserRouter(routes(queryClient), {
+export const router = (queryClient: QueryClient) => {
+  const redirectPath = manageRedirections();
+
+  if (redirectPath) {
+    const newUrl =
+      window.location.origin + basename.replace(/\/$/g, '') + redirectPath;
+    window.history.replaceState(null, '', newUrl);
+  }
+  return createBrowserRouter(routes(queryClient), {
     basename,
   });
+};

--- a/frontend/src/routes/redirections/index.tsx
+++ b/frontend/src/routes/redirections/index.tsx
@@ -1,0 +1,21 @@
+import { matchPath } from 'react-router-dom';
+
+/** Check old format URL and redirect if needed */
+export const manageRedirections = (): string | null => {
+  const hashLocation = window.location.hash.substring(1);
+
+  if (hashLocation) {
+    let redirectPath = '';
+    const isPath = matchPath('/view/:id', hashLocation);
+
+    if (isPath) {
+      // Redirect to the new format
+      redirectPath = `/id/${isPath?.params.id}`;
+    }
+
+    return redirectPath;
+  }
+
+  // No redirection needed
+  return null;
+};

--- a/frontend/src/routes/root/index.tsx
+++ b/frontend/src/routes/root/index.tsx
@@ -1,26 +1,7 @@
 import { Layout, LoadingScreen, useEdificeClient } from '@edifice.io/react';
 
-import { matchPath } from 'react-router-dom';
-
-import { basename } from '..';
-
 /** Check old format URL and redirect if needed */
 export const loader = async () => {
-  const hashLocation = location.hash.substring(1);
-
-  // Check if the URL is an old format (angular root with hash) and redirect to the new format
-  if (hashLocation) {
-    const isPath = matchPath('/view/:id', hashLocation);
-
-    if (isPath) {
-      // Redirect to the new format
-      const redirectPath = `/id/${isPath?.params.id}`;
-      location.replace(
-        location.origin + basename.replace(/\/$/g, '') + redirectPath,
-      );
-    }
-  }
-
   return null;
 };
 


### PR DESCRIPTION
# Description

This PR refactors the URL redirection logic for handling old hash-based routes by moving it from the root route loader to the router initialization phase. This ensures redirections occur before the router is created rather than during route loading.

Key Changes:

- Extracted redirection logic into a dedicated manageRedirections function in a new redirections module
- Moved redirection execution from route loader to router creation in routes/index.tsx
- Changed from location.replace() to window.history.replaceState() for smoother navigation

>

## Type of change

Please check options that are relevant.

- [x] Chore (PATCH)
- [ ] Doc (PATCH)
- [ ] Bug fix (PATCH)
- [ ] New feature (MINOR)
- [ ] Breaking change (MAJOR)

> PATCH: refactor, internal or non-breaking change which fixes an issue
>
> MINOR: non-breaking change which adds functionality
>
> MAJOR: fix or feature that would cause existing functionality to not work as expected

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
